### PR TITLE
Add profile-based screen routing on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,15 @@
       document.getElementById('profile-screen').classList.add('hidden');
       document.getElementById('login-screen').classList.remove('hidden');
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const profile = localStorage.getItem('briefly_profile');
+      if (profile) {
+        showScreen('dashboard');
+      } else {
+        showScreen('login');
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Check for an existing `briefly_profile` in localStorage on DOMContentLoaded
- Show dashboard if profile exists, otherwise show login screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8976a17083268185c362a27c33e0