### PR TITLE
Add aria-labelledby attributes for screen headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
   </style>
 </head>
 <body>
-  <section id="login">
-    <h1>Login</h1>
+  <section id="login" aria-labelledby="login-heading">
+    <h1 id="login-heading">Login</h1>
     <form>
       <div class="form-group">
         <label for="login-email">Email</label>
@@ -36,8 +36,8 @@
     </form>
   </section>
 
-  <section id="profile" style="display: none;">
-    <h1>Profile Setup</h1>
+  <section id="profile" style="display: none;" aria-labelledby="profile-heading">
+    <h1 id="profile-heading">Profile Setup</h1>
     <form>
       <div class="form-group">
         <label for="first-name">First Name</label>
@@ -61,8 +61,8 @@
     </form>
   </section>
 
-  <section id="account" style="display: none;">
-    <h1>Account Details</h1>
+  <section id="account" style="display: none;" aria-labelledby="account-heading">
+    <h1 id="account-heading">Account Details</h1>
     <form id="account-form">
       <div class="form-group">
         <label for="case-number">Case Number</label>
@@ -98,8 +98,8 @@
     </form>
   </section>
 
-  <section id="dashboard" style="display: none;">
-    <h1>Dashboard</h1>
+  <section id="dashboard" style="display: none;" aria-labelledby="dashboard-heading">
+    <h1 id="dashboard-heading">Dashboard</h1>
     <p>Welcome to your dashboard.</p>
     <div class="button-group">
       <button type="button" class="btn btn-secondary" onclick="showScreen('profile')">Back</button>


### PR DESCRIPTION
## Summary
- link each screen `<section>` to its heading using `aria-labelledby`
- assign matching `id` attributes to `<h1>` elements in login, profile, account, and dashboard sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8dcea2508326b49272a6d0e05748