### PR TITLE
Use DOM APIs for document rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -236,6 +236,7 @@
     const setJSON = (k, v) => localStorage.setItem(k, JSON.stringify(v));
     const del = (k) => localStorage.removeItem(k);
     const isAccountComplete = acc => !!(acc?.caseNumber?.trim() && acc?.role);
+    const safe = (str) => String(str ?? "");
 
       const loadCards = () => {
         const stored = getJSON(K_CARDS);
@@ -487,13 +488,27 @@
         const tr = document.createElement("tr");
         const added = new Date(d.addedAt||Date.now()).toLocaleString();
         const icon = fileIcon(d.name);
-        tr.innerHTML = `
-          <td>${icon} ${d.displayName || d.name}</td>
-          <td>${Math.max(1, Math.round((d.size||0)/1024))}</td>
-          <td>${d.type || "—"}</td>
-          <td>${d.category || "Case Document"}</td>
-          <td>${added}</td>
-        `;
+
+        const tdName = document.createElement("td");
+        tdName.textContent = `${icon} ${safe(d.displayName || d.name)}`;
+        tr.appendChild(tdName);
+
+        const tdSize = document.createElement("td");
+        tdSize.textContent = String(Math.max(1, Math.round((d.size||0)/1024)));
+        tr.appendChild(tdSize);
+
+        const tdType = document.createElement("td");
+        tdType.textContent = safe(d.type || "—");
+        tr.appendChild(tdType);
+
+        const tdCategory = document.createElement("td");
+        tdCategory.textContent = safe(d.category || "Case Document");
+        tr.appendChild(tdCategory);
+
+        const tdAdded = document.createElement("td");
+        tdAdded.textContent = added;
+        tr.appendChild(tdAdded);
+
         tbody.appendChild(tr);
       });
       renderCards();
@@ -573,20 +588,45 @@
       docs.forEach((d,i)=>{
         const tr = document.createElement("tr");
         const icon = fileIcon(d.name);
-        tr.innerHTML = `
-          <td>${icon} <input type="text" value="${d.displayName||d.name}" data-name-idx="${i}" style="width:100%" /></td>
-          <td>${Math.max(1,Math.round(d.size/1024))}</td>
-          <td>${d.type || "—"}</td>
-          <td>
-            <select data-idx="${i}">
-              <option ${d.category==="Case Document"?"selected":""}>Case Document</option>
-              <option ${d.category==="Motion"?"selected":""}>Motion</option>
-              <option ${d.category==="Subpoena"?"selected":""}>Subpoena</option>
-              <option ${d.category==="Other"?"selected":""}>Other</option>
-            </select>
-          </td>
-          <td><button type="button" data-rm="${i}">Remove</button></td>
-        `;
+
+        const tdName = document.createElement("td");
+        tdName.append(document.createTextNode(icon + " "));
+        const input = document.createElement("input");
+        input.type = "text";
+        input.value = safe(d.displayName || d.name);
+        input.dataset.nameIdx = String(i);
+        input.style.width = "100%";
+        tdName.appendChild(input);
+        tr.appendChild(tdName);
+
+        const tdSize = document.createElement("td");
+        tdSize.textContent = String(Math.max(1,Math.round(d.size/1024)));
+        tr.appendChild(tdSize);
+
+        const tdType = document.createElement("td");
+        tdType.textContent = safe(d.type || "—");
+        tr.appendChild(tdType);
+
+        const tdCategory = document.createElement("td");
+        const select = document.createElement("select");
+        select.dataset.idx = String(i);
+        ["Case Document","Motion","Subpoena","Other"].forEach(label=>{
+          const opt = document.createElement("option");
+          opt.textContent = label;
+          if (d.category === label) opt.selected = true;
+          select.appendChild(opt);
+        });
+        tdCategory.appendChild(select);
+        tr.appendChild(tdCategory);
+
+        const tdRm = document.createElement("td");
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.dataset.rm = String(i);
+        btn.textContent = "Remove";
+        tdRm.appendChild(btn);
+        tr.appendChild(tdRm);
+
         docsTableBody.appendChild(tr);
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test1234",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jsdom": "^22.1.0"
+  }
+}

--- a/test/renderDocsTable.test.js
+++ b/test/renderDocsTable.test.js
@@ -1,0 +1,32 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('file name with <script> renders as text', async () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    url: 'http://localhost',
+    beforeParse(window) {
+      window.HTMLElement.prototype.focus = function() {};
+      const docs = [{
+        id: '1',
+        name: '<script>alert(1)</script>.txt',
+        displayName: '<script>alert(1)</script>.txt',
+        size: 1024,
+        type: 'text/plain',
+        category: 'Case Document',
+        addedAt: Date.now()
+      }];
+      window.localStorage.setItem('briefly:v1:docs', JSON.stringify(docs));
+    }
+  });
+  // wait for scripts to run
+  await new Promise(resolve => dom.window.addEventListener('load', resolve));
+  const td = dom.window.document.querySelector('#docsTable tbody td');
+  assert.ok(td, 'table cell exists');
+  assert.match(td.textContent, /<script>alert\(1\)<\/script>.txt/);
+  assert.strictEqual(td.querySelector('script'), null);
+});


### PR DESCRIPTION
## Summary
- replace template innerHTML in dashboard and docs table with DOM element creation
- sanitize user-supplied strings before inserting into DOM
- add regression test for filenames containing `<script>`

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_689ea3d1b5308326b7d0831997074163